### PR TITLE
:tada: 提交cascader级联选择器组件

### DIFF
--- a/src/components/cascader/index.js
+++ b/src/components/cascader/index.js
@@ -1,0 +1,7 @@
+import PyCascader from './src/cascader.vue';
+
+PyCascader.install = function(Vue) {
+  Vue.component(PyCascader.name, PyCascader);
+};
+
+export default PyCascader;

--- a/src/components/cascader/index.json
+++ b/src/components/cascader/index.json
@@ -1,0 +1,6 @@
+{
+  "dev": true,
+  "prototype": false,
+  "map": [
+  ]
+}

--- a/src/components/cascader/src/cascader-menu-item.vue
+++ b/src/components/cascader/src/cascader-menu-item.vue
@@ -1,0 +1,117 @@
+<template>
+  <li class="py-cascader-menu-item py-cascader-menu-item:hover"
+    :class="disabled ? 'py-cascader-menu-item--disable' : isActive ?
+      'py-cascader-menu-item--active' : ''"
+      @click="selectItem" @mouseover="triggerType === 'hover' && selectItem($event)">
+      <div v-if="type === 'select'">
+        {{option[props.label]}}
+        <i class="py-icon iconfont icon-return"
+          v-show="option[props.children]"></i>
+      </div>
+      <div v-else v-html="html">
+      </div>
+  </li>
+</template>
+<script>
+export default {
+  name: 'PyCascaderMenuItem',
+  props: {
+    // item显示类型，filter 过滤模式 | select 选择模式
+    type: {
+      type: String,
+      required: true,
+    },
+    // 当前item绑定的option
+    option: {
+      type: Object,
+      required: false,
+    },
+    // 当前item的菜单层级
+    menuIndex: {
+      type: Number,
+      required: false,
+    },
+    // item触发下一级方式
+    triggerType: {
+      type: String,
+      default: 'click',
+    },
+    // 是否选中当前选项
+    isActive: {
+      type: Boolean,
+      default: false,
+    },
+    // 分割符
+    separator: {
+      type: String,
+      default: '/',
+    },
+    // option对象的key名称
+    props: {
+      type: Object,
+      default() {
+        return {
+          value: 'value',
+          label: 'label',
+          children: 'children',
+          disabled: 'disabled',
+        };
+      },
+    },
+    // 过滤关键字
+    filterValue: {
+      type: String,
+      default: null,
+    },
+    // 过滤出的option数组
+    filterOptionArr: {
+      type: Array,
+      required: false,
+    },
+  },
+  computed: {
+    html() {
+      if (this.type === 'filter') {
+        const { label } = this.props;
+        const str = this.filterOptionArr
+          .map(opt => opt[label])
+          .join(` ${this.separator} `);
+        const reg = new RegExp(this.filterValue, 'ig');
+        return str.replace(reg, '<strong>$&</strong>');
+      }
+      return '';
+    },
+    disabled() {
+      const { disabled } = this.props;
+      if (this.type === 'filter') {
+        const disabledarr = this.filterOptionArr.map(opt => opt[disabled]);
+        return disabledarr.indexOf(true) !== -1;
+      }
+      return this.option[disabled];
+    },
+  },
+  methods: {
+    selectItem(event) {
+      if (this.disabled) return;
+
+      const { children } = this.props;
+      if (event.type === 'click') {
+        if (this.type === 'select') {
+          this.$emit('select-menu', {
+            option: this.option,
+            menuIndex: this.menuIndex,
+          });
+        } else {
+          this.$emit('select-filter-menu', this.filterOptionArr);
+        }
+      } else if (event.type === 'mouseover' && this.option[children]) {
+        this.$emit('select-menu', {
+          option: this.option,
+          menuIndex: this.menuIndex,
+          options: this.options,
+        });
+      }
+    },
+  },
+};
+</script>

--- a/src/components/cascader/src/cascader-menu.vue
+++ b/src/components/cascader/src/cascader-menu.vue
@@ -1,0 +1,10 @@
+<template>
+  <ul class="py-cascader-menu">
+    <slot></slot>
+  </ul>
+</template>
+<script>
+export default {
+  name: 'PyCascaderMune',
+};
+</script>

--- a/src/components/cascader/src/cascader.vue
+++ b/src/components/cascader/src/cascader.vue
@@ -1,0 +1,528 @@
+<template>
+  <div class="py-cascader" :class="size ? 'py-cascader--' + size : ''">
+    <div class="py-cascader__input-box" @click="!disabled && toggleMenu()"
+      @mouseover="mouseoverHandler" @mouseout="mouseoutHandler">
+      <input ref="cascaderInput" class="py-cascader__input"
+        :class="disabled ? 'py-cascader__input--disabled' : isFocus ?
+        'py-cascader__input--focus' : 'py-cascader__input--unfocus'"
+        :placeholder="placeholderValue" :readonly="!filterable"
+        :disabled="disabled" :value="inputValue"
+        @focus="focusInput" @blur="blurInput"
+        @input="inputFilter" @compositionstart="compositionstartHandler"
+        @compositionend="compositionendHandler"/>
+      <span class="py-cascader__input-icon">
+        <i class="py-icon iconfont icon-delete" v-if="isShowDelete" @click="clear()"
+          ></i>
+        <i class="py-icon iconfont icon-return" v-else
+          :class="isShowMenu ? 'icon-return--up' : 'icon-return--down'"></i>
+      </span>
+    </div>
+     <div class="py-cascader__menu" v-show="isShowMenu" @click="clickMenu($event)"
+      :class="menuClass">
+        <py-cascader-menu v-if="filterable && isShowFilterMenu">
+          <py-cascader-menu-item type="filter" v-for="(item, index) in filterOptions" :key="index"
+            @select-filter-menu="selectFilterMenu" :filter-value="filterValue" :props="props"
+            :filter-option-arr="item" :separator="separator">
+          </py-cascader-menu-item>
+          <py-cascader-menu-item type="select" v-if="filterOptions.length === 0"
+            :option="{ label: '无匹配数据', disabled: true }">
+          </py-cascader-menu-item>
+        </py-cascader-menu>
+        <py-cascader-menu v-else v-for="(opts, index) in showOptions" :key="index">
+          <py-cascader-menu-item type="select" v-for="item in opts" :key="item.value"
+            :option="item" :menuIndex="index" :trigger-type="triggerType"
+            :isActive="item === selectingData[index]"
+            :props="props" :separator="separator"
+            @select-menu="selectMenu">
+          </py-cascader-menu-item>
+        </py-cascader-menu>
+    </div>
+  </div>
+</template>
+
+<script>
+import PyCascaderMenu from './cascader-menu.vue';
+import PyCascaderMenuItem from './cascader-menu-item.vue';
+
+// 组件class前缀
+// const prefixCls = 'py-cascader';
+
+/**
+ * @description 根据value值，从options数组中找出option
+ * @param {stirng} targetValue 制定value值
+ * @param {any} options 给定options数组
+ * @param {any} props 给定option对象的key名称
+ */
+function findChildren(targetValue, options, props) {
+  let child;
+  let opt;
+  const { value, children } = props;
+  for (let i = 0; i < options.length; i += 1) {
+    if (targetValue === options[i][value]) {
+      child = options[i][children];
+      opt = options[i];
+      break;
+    }
+  }
+  return {
+    child,
+    opt,
+  };
+}
+
+/**
+ * @description 将一个option的所有children option添加入过滤结果数组
+ * @param {any} opts 被添加的option
+ * @param {any[]} optStack 保存了上一级option的数组
+ * @param {any[]} filterResults 过滤结果数组
+ * @param {any} props 给定option对象的key名称
+ */
+function addChildrenOptions(opts, optStack, filterResults, props) {
+  let currentOptStack = [];
+  const { children } = props;
+  opts.forEach(opt => {
+    currentOptStack = optStack.slice();
+    currentOptStack.push(opt);
+    if (opt[children]) {
+      addChildrenOptions(opt[children], currentOptStack, filterResults, props);
+    } else {
+      filterResults.push(currentOptStack);
+    }
+  });
+}
+
+/**
+ * @description 过滤一个option的所有children option
+ * @param {any} opts 制定value值
+ * @param {RegExp} reg 过滤正则对象
+ * @param {any[]} optStack 保存了上一级option的数组
+ * @param {any[]} filterResults 过滤结果数组
+ * @param {any} props 给定option对象的key名称
+ */
+function filterChildrenOptions(opts, reg, optStack, filterResults, props) {
+  let currentOptStack = [];
+  const { children, label } = props;
+  opts.forEach(opt => {
+    currentOptStack = optStack.slice();
+    currentOptStack.push(opt);
+    if (opt[label].match(reg)) {
+      if (opt[children]) {
+        addChildrenOptions(
+          opt[children],
+          currentOptStack,
+          filterResults,
+          props,
+        );
+      } else {
+        filterResults.push(currentOptStack);
+      }
+    } else if (opt[children]) {
+      filterChildrenOptions(
+        opt[children],
+        reg,
+        currentOptStack,
+        filterResults,
+        props,
+      );
+    }
+  });
+}
+
+/**
+ * @description 根据关键字在options中过滤出结果
+ * @param {any} opts 制定value值
+ * @param {string} keyWorld 过滤正则对象
+ * @param {any} props 给定option对象的key名称
+ */
+function filterKeyWorkd(opts, keyWorld, props) {
+  let optStack = [];
+  const filterResults = [];
+  const reg = new RegExp(keyWorld, 'i');
+  const { label, children } = props;
+  opts.forEach(opt => {
+    optStack = [];
+    optStack.push(opt);
+
+    if (opt[label].match(reg)) {
+      if (opt[children]) {
+        addChildrenOptions(opt[children], optStack, filterResults, props);
+      } else {
+        filterResults.push(optStack);
+      }
+    } else if (opt[children]) {
+      filterChildrenOptions(opt[children], reg, optStack, filterResults, props);
+    }
+  });
+  return filterResults;
+}
+
+export default {
+  name: 'PyCascader',
+  components: {
+    'py-cascader-menu': PyCascaderMenu,
+    'py-cascader-menu-item': PyCascaderMenuItem,
+  },
+  props: {
+    placeholder: {
+      type: String,
+      default: '请选择',
+    },
+    // 数据选项
+    options: {
+      type: Array,
+      required: true,
+    },
+    // 下一级菜单触发方式，click | hover
+    triggerType: {
+      type: String,
+      default: 'click',
+    },
+    // 分割符
+    separator: {
+      type: String,
+      default: '/',
+    },
+    // 选择即改变，可用于选择任意一级菜单的选项。
+    changeOnSelect: {
+      type: Boolean,
+      default: false,
+    },
+    // 传入选择好的默认值
+    value: {
+      type: Array,
+      default() {
+        return [];
+      },
+    },
+    // 是否显示所有路径
+    showAllLevels: {
+      type: Boolean,
+      default: true,
+    },
+    // 禁止使用
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    // 是否显示清楚图标
+    clearable: {
+      type: Boolean,
+      default: false,
+    },
+    // 添加到菜单的自定义class
+    menuClass: {
+      type: String,
+      default: '',
+    },
+    // 选择器的尺寸大小，medium | small | mini
+    size: {
+      type: String,
+      default: '',
+    },
+    // options对象的key名称
+    props: {
+      type: Object,
+      default() {
+        return {
+          value: 'value',
+          label: 'label',
+          children: 'children',
+          disabled: 'disabled',
+        };
+      },
+    },
+    // 是否可以过滤搜索
+    filterable: {
+      type: Boolean,
+      default: false,
+    },
+    // 搜索关键词输入的去抖延迟，毫秒
+    debounce: {
+      type: Number,
+      default: 300,
+    },
+    // 过滤前回调函数
+    beforeFilter: {
+      type: Function,
+      required: false,
+    },
+  },
+  data() {
+    return {
+      // class name前缀
+      // prefixCls,
+      isFocus: false,
+      isShowMenu: false,
+      // 正在选择中的数据
+      selectingData: [],
+      // 最终选好的数据
+      selectedData: [],
+      // 失去焦点定时器
+      blurTimer: null,
+      // 鼠标是否悬停在选择器
+      mouseIn: false,
+      // 是否正在输入拼音中文
+      isInputChinese: false,
+      // 去抖延迟timer
+      filterTimer: null,
+      // 用户输入的过滤文本
+      filterValue: null,
+      // 是否显示过滤菜单
+      isShowFilterMenu: false,
+      // 过滤出的选项
+      filterOptions: [],
+    };
+  },
+  watch: {
+    value: {
+      immediate: true,
+      handler(newVal) {
+        // 检测value与当前 selectedData 的值是否一样
+        const oldSelectedValue = this.selectedData.map(item => item[this.props.value]);
+        let isSame = true;
+        const length =
+          newVal.length > oldSelectedValue.length
+            ? newVal.length
+            : oldSelectedValue.length;
+        for (let i = 0; i < length; i += 1) {
+          if (oldSelectedValue[i] !== newVal[i]) {
+            isSame = false;
+            break;
+          }
+        }
+        if (isSame) return;
+
+        const selectedValue = newVal.slice();
+        let currentOpts = this.options;
+        this.selectingData = [];
+        this.selectedData = [];
+
+        for (let i = 0; i < selectedValue.length; i += 1) {
+          const value = selectedValue[i];
+          const { child, opt } = findChildren(value, currentOpts, this.props);
+          if (opt.disabled) {
+            break;
+          } else {
+            this.selectingData.push(opt);
+            this.selectedData.push(opt);
+          }
+          if (child) {
+            currentOpts = child;
+          } else {
+            break;
+          }
+        }
+      },
+    },
+    selectedData(newVal) {
+      const { value } = this.props;
+      this.$emit('input', newVal.map(item => item[value]));
+      this.$emit('change', newVal.map(item => item[value]));
+    },
+  },
+  computed: {
+    placeholderValue() {
+      if (this.filterable && this.isFocus && this.filterValue === null) {
+        // 当输入关键词进行过滤时，让当前选择结果成为placeholder
+        const { label } = this.props;
+        if (this.showAllLevels) {
+          return (
+            this.selectedData
+              .map(data => data[label])
+              .join(` ${this.separator} `) || this.placeholder
+          );
+        }
+        return (
+          this.selectedData.map(data => data[label]).pop() || this.placeholder
+        );
+      }
+      return this.placeholder;
+    },
+    inputValue() {
+      if (this.filterable && this.isFocus) {
+        if (this.filterValue !== null) {
+          return this.filterValue;
+        }
+        return '';
+      }
+      const { label } = this.props;
+      if (this.showAllLevels) {
+        return this.selectedData
+          .map(data => data[label])
+          .join(` ${this.separator} `);
+      }
+      return this.selectedData.map(data => data[label]).pop() || '';
+    },
+    isShowDelete() {
+      if (!this.clearable) {
+        return false;
+      } else if (
+        this.mouseIn &&
+        (this.value.length > 0 || this.selectedData.length > 0)
+      ) {
+        return true;
+      }
+      return false;
+    },
+    showOptions() {
+      const showOptions = [this.options];
+      const { children } = this.props;
+      for (let i = 0; i < this.selectingData.length; i += 1) {
+        if (this.selectingData[i][children]) {
+          showOptions.push(this.selectingData[i][children]);
+        }
+      }
+      return showOptions;
+    },
+  },
+  methods: {
+    compositionstartHandler() {
+      this.isInputChinese = true;
+    },
+    compositionendHandler(event) {
+      this.isInputChinese = false;
+      this.filterValue = this.filterValue || '';
+      this.filter(this.filterValue + event.data);
+    },
+    inputFilter(event) {
+      if (this.isInputChinese) return;
+      this.filter(event.target.value);
+    },
+    filter(value) {
+      if (this.filterTimer) {
+        clearTimeout(this.filterTimer);
+      }
+      this.filterValue = value;
+
+      // 运行before-filter方法 并检测运行结果
+      if (this.beforeFilter) {
+        const res = this.beforeFilter(value);
+        if (res === false) {
+          return;
+        } else if (res instanceof Promise) {
+          res
+            .then(() => {
+              this.filterTimer = setTimeout(() => {
+                // 根据关键字过滤出options
+                this.filterOptions = filterKeyWorkd(
+                  this.options,
+                  this.filterValue,
+                  this.props,
+                );
+
+                if (value.length > 0) {
+                  this.isShowFilterMenu = true;
+                } else {
+                  this.isShowFilterMenu = false;
+                }
+                this.filterTimer = null;
+              }, this.debounce);
+            })
+            .catch(e => e);
+          return;
+        }
+      }
+
+      this.filterTimer = setTimeout(() => {
+        this.filterOptions = filterKeyWorkd(
+          this.options,
+          this.filterValue,
+          this.props,
+        );
+
+        if (value.length > 0) {
+          this.isShowFilterMenu = true;
+        } else {
+          this.isShowFilterMenu = false;
+        }
+        this.filterTimer = null;
+      }, this.debounce);
+    },
+    // 从过滤出的item中选择
+    selectFilterMenu(values) {
+      this.selectedData = values;
+      this.filterValue = null;
+    },
+    clear() {
+      this.selectedData = [];
+    },
+    mouseoverHandler() {
+      this.mouseIn = true;
+    },
+    mouseoutHandler() {
+      this.mouseIn = false;
+    },
+    focusInput(event) {
+      this.isFocus = true;
+      if (!this.blurTimer) {
+        this.$emit('focus', event);
+      }
+    },
+    blurInput(event) {
+      this.blurTimer = setTimeout(() => {
+        this.$emit('blur', event);
+        this.isFocus = false;
+        this.isShowMenu = false;
+        this.blurTimer = null;
+        this.filterValue = null;
+        this.isShowFilterMenu = false;
+      }, 300);
+    },
+    // 选择菜单
+    selectMenu(data) {
+      const { option, menuIndex } = data;
+      this.selectingData.splice(menuIndex);
+      this.selectingData.push(option);
+
+      if (option[this.props.children]) {
+        // 还有下一级选项
+        if (this.changeOnSelect) {
+          this.selectedData = this.selectingData.slice();
+        } else {
+          // 点击非最后一级的选项才会触发 'active-item-change' 事件
+          this.$emit(
+            'active-item-change',
+            this.selectingData.map(item => item[this.props.value]),
+          );
+        }
+      } else {
+        // 无下一级选项
+        this.selectedData = this.selectingData.slice();
+        this.isShowMenu = false;
+      }
+    },
+    // 点击菜单
+    clickMenu() {
+      // 让输入框重新聚焦
+      this.$refs.cascaderInput.focus();
+      if (this.blurTimer) {
+        clearTimeout(this.blurTimer);
+        this.blurTimer = null;
+      }
+    },
+    toggleMenu() {
+      this.isShowMenu = !this.isShowMenu;
+      if (this.isShowMenu) {
+        const selectedValue = this.selectedData.map(data => data[this.props.value]);
+        let currentOpts = this.options;
+        this.selectingData = [];
+
+        for (let i = 0; i < selectedValue.length; i += 1) {
+          const value = selectedValue[i];
+          const { child, opt } = findChildren(value, currentOpts, this.props);
+          if (opt.disabled) {
+            break;
+          } else {
+            this.selectingData.push(opt);
+          }
+          if (child) {
+            currentOpts = child;
+          } else {
+            break;
+          }
+        }
+      }
+    },
+  },
+};
+</script>

--- a/src/router.js
+++ b/src/router.js
@@ -69,5 +69,11 @@ export default new Router({
       component: () =>
         import(/* webpackChunkName: "switch" */ './testsDemo/switch/Switch.vue'),
     },
+    {
+      path: '/cascader',
+      name: 'cascader',
+      component: () =>
+        import(/* webpackChunkName: "cascader" */ './testsDemo/cascader/cascader.vue'),
+    },
   ],
 });

--- a/src/styles/src/cascader.scss
+++ b/src/styles/src/cascader.scss
@@ -1,0 +1,158 @@
+@charset "UTF-8";
+
+@import '../../base/style.scss';
+@import '../../base/themes.scss';
+// 组件class前缀
+$prefixCls: 'py-cascader';
+$disable-color: #c0c4cc;
+
+// cascader.scss组件
+.#{$prefixCls} {
+  display: inline-block;
+  position: relative;
+  min-width: 222px;
+
+  &.#{$prefixCls}--mini {
+    min-width: 193px;
+    .#{$prefixCls}__input-box {
+      font-size: 12px;
+      line-height: 28px;
+      height: 28px;
+    }
+  }
+
+  &.#{$prefixCls}--small {
+    min-width: 215px;
+    .#{$prefixCls}__input-box {
+      font-size: 13px;
+      line-height: 32px;
+      height: 32px;
+    }
+  }
+  &.#{$prefixCls}--medium {
+    min-width: 217px;
+    .#{$prefixCls}__input-box {
+      font-size: 14px;
+      line-height: 36px;
+      height: 36px;
+    }
+  }
+
+  &__input-box {
+    height: 40px;
+    line-height: 40px;
+    font-size: 14px;
+    position: relative;
+  }
+
+  &__input {
+    width: 100%;
+    height: 100%;
+    padding: 0px 30px 0px 15px;
+    border-radius: $border-radius;
+    border: 1px solid;
+    transition: border-color 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
+
+    white-space: nowrap;
+    text-overflow: ellipsis;
+
+    cursor: pointer;
+    &--unfocus {
+      border-color: $border-color;
+      background: $bg-color;
+    }
+    &--focus {
+      border-color: $border-color-active;
+      background: $bg-color;
+    }
+    &--disabled {
+      color: $disable-color;
+      background: rgba(220, 222, 226, 0.27);
+      cursor: not-allowed;
+    }
+  }
+
+  &__input-icon {
+    position: absolute;
+    height: 100%;
+    right: 0px;
+    top: 0;
+    text-align: center;
+    color: #c0c4cc;
+    cursor: pointer;
+    .py-icon {
+      padding: 0px 8px;
+      font-size: 14px;
+      height: 100%;
+      line-height: 40px;
+    }
+    .icon-return {
+      transition: transform 0.3s;
+      &--down {
+        transform: rotate(-90deg);
+      }
+      &--up {
+        transform: rotate(90deg);
+      }
+    }
+  }
+
+  &__menu {
+    position: absolute;
+    top: 50px;
+    left: 0px;
+  
+    display: flex;
+    z-index: 10;
+  
+    border: 1px solid #e4e7ed;
+    border-radius: 2px;
+    box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
+  }
+}
+
+
+// cascader-menu组件
+.#{$prefixCls}-menu {
+  padding: 6px 0px;
+  max-height: 204px;
+
+  border: 1px solid $border-color;
+  overflow: auto;
+  background: #fff;
+}
+
+// cascader-menu-item组件
+.#{$prefixCls}-menu-item {
+  min-width: 160px;
+  padding: 8px 20px;
+  position: relative;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: $color;
+  height: 34px;
+  line-height: 1.5;
+  box-sizing: border-box;
+  font-size: 14px;
+
+  &:hover {
+    background-color: #f5f7fa;
+  }
+
+  &.#{$prefixCls}-menu-item--disable {
+    color: $disable-color;
+    background-color: #fff;
+    cursor: not-allowed;
+  }
+
+  &.#{$prefixCls}-menu-item--active {
+    color: $color-active;
+  }
+
+  .icon-return {
+    transform: rotate(-180deg);
+    float: right;
+    color: $disable-color;
+  }
+}

--- a/src/styles/src/index.scss
+++ b/src/styles/src/index.scss
@@ -1,2 +1,3 @@
 @import './common.scss';
 @import './button.scss';
+@import './cascader.scss';

--- a/src/testsDemo/cascader/cascader.vue
+++ b/src/testsDemo/cascader/cascader.vue
@@ -1,0 +1,200 @@
+<template>
+  <div class="container">
+    <div class="demo-box">
+      <h3 class="demo-box__title">基础用法</h3>
+      <p class="demo-box__desc">click触发子菜单与hover触发子菜单</p>
+      <div class="demo-box__cascader-box">
+        <py-cascader class="demo-cascader" :placeholder="'click触发'"
+          :options="demoOptions1" @blur="logBlur"
+          @focus="logFocus" @change="logChange"
+          @active-item-change="logActiveItemChange"
+          clearable mune-class="demo-mune demo-mune2"></py-cascader>
+        <py-cascader class="demo-cascader" :placeholder="'hover触发'"
+          :options="demoOptions1" :trigger-type="'hover'"
+          @change="logChange" @active-item-change="logActiveItemChange"></py-cascader>
+      </div>
+    </div>
+
+    <div class="demo-box">
+      <h3 class="demo-box__title">禁用选项</h3>
+      <p class="demo-box__desc">通过在数据源中设置 disabled 字段来声明该选项是禁用的</p>
+      <div class="demo-box__cascader-box">
+        <py-cascader class="demo-cascader" :options="demoOptions2"></py-cascader>
+      </div>
+    </div>
+
+    <div class="demo-box">
+      <h3 class="demo-box__title">仅显示最后一级</h3>
+      <p class="demo-box__desc">可以仅在输入框中显示选中项最后一级的标签，而不是选中项所在的完整路径。
+        属性show-all-levels定义了是否显示完整的路径，将其赋值为false则仅显示最后一级</p>
+      <div class="demo-box__cascader-box">
+        <py-cascader class="demo-cascader" :options="demoOptions2"
+          :show-all-levels="false"></py-cascader>
+      </div>
+    </div>
+
+    <div class="demo-box">
+      <h3 class="demo-box__title">默认值</h3>
+      <p class="demo-box__desc">通过value字段（或者v-model），以数组的形式设置默认值</p>
+      <div class="demo-box__cascader-box">
+        <py-cascader class="demo-cascader" :options="demoOptions1" v-model="defaultValues"
+          @input="selectData"></py-cascader>
+      </div>
+    </div>
+
+    <div class="demo-box">
+      <h3 class="demo-box__title">选择即改变</h3>
+      <p class="demo-box__desc">点击或移入选项即表示选中该项，可用于选择任意一级菜单的选项。</p>
+      <div class="demo-box__cascader-box">
+        <py-cascader class="demo-cascader" :options="demoOptions1" change-on-select
+          @change="logChange" @active-item-change="logActiveItemChange"></py-cascader>
+      </div>
+    </div>
+
+    <div class="demo-box">
+      <h3 class="demo-box__title">禁止使用</h3>
+      <p class="demo-box__desc">设置disabled属性，让选择器禁止使用</p>
+      <div class="demo-box__cascader-box">
+        <py-cascader class="demo-cascader" :options="demoOptions1"
+          change-on-select disabled></py-cascader>
+      </div>
+    </div>
+
+    <div class="demo-box">
+      <h3 class="demo-box__title">size改变大小</h3>
+      <p class="demo-box__desc">设置size属性，让选择器改变默认大小，可选值为 mini、small、medium</p>
+      <div class="demo-box__cascader-box">
+        <py-cascader class="demo-cascader" :options="demoOptions1" size="mini"
+          change-on-select></py-cascader>
+        <py-cascader class="demo-cascader" :options="demoOptions1" size="small"
+          change-on-select></py-cascader>
+        <py-cascader class="demo-cascader" :options="demoOptions1" size="medium"
+          change-on-select></py-cascader>
+      </div>
+    </div>
+
+    <div class="demo-box">
+      <h3 class="demo-box__title">动态加载次级选项</h3>
+      <p class="demo-box__desc">当选中某一级时，动态加载该级下的选项。本例的选项数据源在初始化时
+        不包含城市数据。利用active-item-change事件，可以在用户点击某个省份时拉取该省份下的城市数据</p>
+      <div class="demo-box__cascader-box">
+        <py-cascader class="demo-cascader" :options="demoOptions3"
+          @active-item-change="loadOptions" :props="demoOptions3Props"></py-cascader>
+      </div>
+    </div>
+
+    <div class="demo-box">
+      <h3 class="demo-box__title">可搜索</h3>
+      <p class="demo-box__desc">可以快捷地搜索选项并选择。</p>
+      <div class="demo-box__cascader-box">
+        <py-cascader class="demo-cascader" placeholder="试试搜索：组件" filterable :debounce="1000"
+          :options="demoOptions2"></py-cascader>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+import PyCascader from '../../components/cascader';
+import {
+  demoOptions1,
+  demoOptions2,
+  demoOptions3,
+  demoOptions3Props,
+} from './mock';
+
+export default {
+  components: {
+    'py-cascader': PyCascader,
+  },
+  data() {
+    return {
+      demoOptions1,
+      demoOptions2,
+      demoOptions3,
+      demoOptions3Props,
+      defaultValues: ['zhinan', 'shejiyuanze', 'yizhi'],
+    };
+  },
+  methods: {
+    selectData(values) {
+      console.log(values);
+    },
+    logBlur(event) {
+      console.log('blur');
+      console.log(event);
+    },
+    logFocus(event) {
+      console.log('logFocus');
+      console.log(event);
+    },
+    logChange(values) {
+      console.log('change');
+      console.log(values);
+    },
+    logActiveItemChange(values) {
+      console.log('active-item-change');
+      console.log(values);
+    },
+    loadOptions(values) {
+      console.log('active-item-change');
+      console.log(values);
+      if (values.indexOf('江苏') !== -1) {
+        setTimeout(() => {
+          this.demoOptions3[0].cities = [
+            {
+              myValue: '苏州',
+              myLabel: '苏州',
+            },
+            {
+              myValue: '温州',
+              myLabel: '温州',
+            },
+          ];
+        }, 1000);
+      } else if (values.indexOf('深圳') !== -1) {
+        setTimeout(() => {
+          this.demoOptions3[1].cities[0].cities = [
+            {
+              myValue: '宝安',
+              myLabel: '宝安',
+            },
+            {
+              myValue: '福田',
+              myLabel: '福田',
+            },
+          ];
+        }, 1000);
+      }
+    },
+    beforeFilter(str) {
+      console.log(`beforeFilter： ${str}`);
+      return new Promise((resolve, reject) => {
+        setTimeout(() => {
+          reject(new Error('stop filter'));
+        }, 2000);
+      });
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.container {
+  padding: 400px 30px;
+}
+.demo-box {
+  margin: 30px 0px;
+  &__title {
+    margin: 10px 0px;
+  }
+  &__desc {
+    margin: 10px 0px;
+  }
+  &__cascader-box {
+    display: flex;
+  }
+}
+.demo-cascader {
+  margin-right: 100px;
+}
+</style>

--- a/src/testsDemo/cascader/mock.js
+++ b/src/testsDemo/cascader/mock.js
@@ -1,0 +1,570 @@
+export const demoOptions1 = [
+  {
+    value: 'zhinan',
+    label: '指南',
+    children: [
+      {
+        value: 'shejiyuanze',
+        label: '设计原则',
+        children: [
+          {
+            value: 'yizhi',
+            label: '一致',
+          },
+          {
+            value: 'fankui',
+            label: '反馈',
+          },
+          {
+            value: 'xiaolv',
+            label: '效率',
+          },
+          {
+            value: 'kekong',
+            label: '可控',
+          },
+        ],
+      },
+      {
+        value: 'daohang',
+        label: '导航',
+        children: [
+          {
+            value: 'cexiangdaohang',
+            label: '侧向导航',
+          },
+          {
+            value: 'dingbudaohang',
+            label: '顶部导航',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    value: 'zujian',
+    label: '组件',
+    children: [
+      {
+        value: 'basic',
+        label: 'Basic',
+        children: [
+          {
+            value: 'layout',
+            label: 'Layout 布局',
+          },
+          {
+            value: 'color',
+            label: 'Color 色彩',
+          },
+          {
+            value: 'typography',
+            label: 'Typography 字体',
+          },
+          {
+            value: 'icon',
+            label: 'Icon 图标',
+          },
+          {
+            value: 'button',
+            label: 'Button 按钮',
+          },
+        ],
+      },
+      {
+        value: 'form',
+        label: 'Form',
+        children: [
+          {
+            value: 'radio',
+            label: 'Radio 单选框',
+          },
+          {
+            value: 'checkbox',
+            label: 'Checkbox 多选框',
+          },
+          {
+            value: 'input',
+            label: 'Input 输入框',
+          },
+          {
+            value: 'input-number',
+            label: 'InputNumber 计数器',
+          },
+          {
+            value: 'select',
+            label: 'Select 选择器',
+          },
+          {
+            value: 'cascader',
+            label: 'Cascader 级联选择器',
+          },
+          {
+            value: 'switch',
+            label: 'Switch 开关',
+          },
+          {
+            value: 'slider',
+            label: 'Slider 滑块',
+          },
+          {
+            value: 'time-picker',
+            label: 'TimePicker 时间选择器',
+          },
+          {
+            value: 'date-picker',
+            label: 'DatePicker 日期选择器',
+          },
+          {
+            value: 'datetime-picker',
+            label: 'DateTimePicker 日期时间选择器',
+          },
+          {
+            value: 'upload',
+            label: 'Upload 上传',
+          },
+          {
+            value: 'rate',
+            label: 'Rate 评分',
+          },
+          {
+            value: 'form',
+            label: 'Form 表单',
+          },
+        ],
+      },
+      {
+        value: 'data',
+        label: 'Data',
+        children: [
+          {
+            value: 'table',
+            label: 'Table 表格',
+          },
+          {
+            value: 'tag',
+            label: 'Tag 标签',
+          },
+          {
+            value: 'progress',
+            label: 'Progress 进度条',
+          },
+          {
+            value: 'tree',
+            label: 'Tree 树形控件',
+          },
+          {
+            value: 'pagination',
+            label: 'Pagination 分页',
+          },
+          {
+            value: 'badge',
+            label: 'Badge 标记',
+          },
+        ],
+      },
+      {
+        value: 'notice',
+        label: 'Notice',
+        children: [
+          {
+            value: 'alert',
+            label: 'Alert 警告',
+          },
+          {
+            value: 'loading',
+            label: 'Loading 加载',
+          },
+          {
+            value: 'message',
+            label: 'Message 消息提示',
+          },
+          {
+            value: 'message-box',
+            label: 'MessageBox 弹框',
+          },
+          {
+            value: 'notification',
+            label: 'Notification 通知',
+          },
+        ],
+      },
+      {
+        value: 'navigation',
+        label: 'Navigation',
+        children: [
+          {
+            value: 'menu',
+            label: 'NavMenu 导航菜单',
+          },
+          {
+            value: 'tabs',
+            label: 'Tabs 标签页',
+          },
+          {
+            value: 'breadcrumb',
+            label: 'Breadcrumb 面包屑',
+          },
+          {
+            value: 'dropdown',
+            label: 'Dropdown 下拉菜单',
+          },
+          {
+            value: 'steps',
+            label: 'Steps 步骤条',
+          },
+        ],
+      },
+      {
+        value: 'others',
+        label: 'Others',
+        children: [
+          {
+            value: 'dialog',
+            label: 'Dialog 对话框',
+          },
+          {
+            value: 'tooltip',
+            label: 'Tooltip 文字提示',
+          },
+          {
+            value: 'popover',
+            label: 'Popover 弹出框',
+          },
+          {
+            value: 'card',
+            label: 'Card 卡片',
+          },
+          {
+            value: 'carousel',
+            label: 'Carousel 走马灯',
+          },
+          {
+            value: 'collapse',
+            label: 'Collapse 折叠面板',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    value: 'ziyuan',
+    label: '资源',
+    children: [
+      {
+        value: 'axure',
+        label: 'Axure Components',
+      },
+      {
+        value: 'sketch',
+        label: 'Sketch Templates',
+      },
+      {
+        value: 'jiaohu',
+        label: '组件交互文档',
+      },
+    ],
+  },
+];
+
+export const demoOptions2 = [
+  {
+    value: 'zhinan',
+    label: '指南',
+    disabled: true,
+    children: [
+      {
+        value: 'shejiyuanze',
+        label: '设计原则',
+        children: [
+          {
+            value: 'yizhi',
+            label: '一致',
+          },
+          {
+            value: 'fankui',
+            label: '反馈',
+          },
+          {
+            value: 'xiaolv',
+            label: '效率',
+          },
+          {
+            value: 'kekong',
+            label: '可控',
+          },
+        ],
+      },
+      {
+        value: 'daohang',
+        label: '导航',
+        children: [
+          {
+            value: 'cexiangdaohang',
+            label: '侧向导航',
+          },
+          {
+            value: 'dingbudaohang',
+            label: '顶部导航',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    value: 'zujian',
+    label: '组件',
+    children: [
+      {
+        value: 'basic',
+        label: 'Basic',
+        children: [
+          {
+            value: 'layout',
+            label: 'Layout 布局',
+          },
+          {
+            value: 'color',
+            label: 'Color 色彩',
+          },
+          {
+            value: 'typography',
+            label: 'Typography 字体',
+          },
+          {
+            value: 'icon',
+            label: 'Icon 图标',
+          },
+          {
+            value: 'button',
+            label: 'Button 按钮',
+          },
+        ],
+      },
+      {
+        value: 'form',
+        label: 'Form',
+        children: [
+          {
+            value: 'radio',
+            label: 'Radio 单选框',
+          },
+          {
+            value: 'checkbox',
+            label: 'Checkbox 多选框',
+          },
+          {
+            value: 'input',
+            label: 'Input 输入框',
+          },
+          {
+            value: 'input-number',
+            label: 'InputNumber 计数器',
+          },
+          {
+            value: 'select',
+            label: 'Select 选择器',
+          },
+          {
+            value: 'cascader',
+            label: 'Cascader 级联选择器',
+          },
+          {
+            value: 'switch',
+            label: 'Switch 开关',
+          },
+          {
+            value: 'slider',
+            label: 'Slider 滑块',
+          },
+          {
+            value: 'time-picker',
+            label: 'TimePicker 时间选择器',
+          },
+          {
+            value: 'date-picker',
+            label: 'DatePicker 日期选择器',
+          },
+          {
+            value: 'datetime-picker',
+            label: 'DateTimePicker 日期时间选择器',
+          },
+          {
+            value: 'upload',
+            label: 'Upload 上传',
+          },
+          {
+            value: 'rate',
+            label: 'Rate 评分',
+          },
+          {
+            value: 'form',
+            label: 'Form 表单',
+          },
+        ],
+      },
+      {
+        value: 'data',
+        label: 'Data',
+        children: [
+          {
+            value: 'table',
+            label: 'Table 表格',
+          },
+          {
+            value: 'tag',
+            label: 'Tag 标签',
+          },
+          {
+            value: 'progress',
+            label: 'Progress 进度条',
+          },
+          {
+            value: 'tree',
+            label: 'Tree 树形控件',
+          },
+          {
+            value: 'pagination',
+            label: 'Pagination 分页',
+          },
+          {
+            value: 'badge',
+            label: 'Badge 标记',
+          },
+        ],
+      },
+      {
+        value: 'notice',
+        label: 'Notice',
+        children: [
+          {
+            value: 'alert',
+            label: 'Alert 警告',
+          },
+          {
+            value: 'loading',
+            label: 'Loading 加载',
+          },
+          {
+            value: 'message',
+            label: 'Message 消息提示',
+          },
+          {
+            value: 'message-box',
+            label: 'MessageBox 弹框',
+          },
+          {
+            value: 'notification',
+            label: 'Notification 通知',
+          },
+        ],
+      },
+      {
+        value: 'navigation',
+        label: 'Navigation',
+        children: [
+          {
+            value: 'menu',
+            label: 'NavMenu 导航菜单',
+          },
+          {
+            value: 'tabs',
+            label: 'Tabs 标签页',
+          },
+          {
+            value: 'breadcrumb',
+            label: 'Breadcrumb 面包屑',
+          },
+          {
+            value: 'dropdown',
+            label: 'Dropdown 下拉菜单',
+          },
+          {
+            value: 'steps',
+            label: 'Steps 步骤条',
+          },
+        ],
+      },
+      {
+        value: 'others',
+        label: 'Others',
+        children: [
+          {
+            value: 'dialog',
+            label: 'Dialog 对话框',
+          },
+          {
+            value: 'tooltip',
+            label: 'Tooltip 文字提示',
+          },
+          {
+            value: 'popover',
+            label: 'Popover 弹出框',
+          },
+          {
+            value: 'card',
+            label: 'Card 卡片',
+          },
+          {
+            value: 'carousel',
+            label: 'Carousel 走马灯',
+          },
+          {
+            value: 'collapse',
+            label: 'Collapse 折叠面板',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    value: 'ziyuan',
+    label: '资源',
+    children: [
+      {
+        value: 'axure',
+        label: 'Axure Components',
+      },
+      {
+        value: 'sketch',
+        label: 'Sketch Templates',
+      },
+      {
+        value: 'jiaohu',
+        label: '组件交互文档',
+      },
+    ],
+  },
+];
+
+export const demoOptions3 = [
+  {
+    myValue: '江苏',
+    myLabel: '江苏',
+    cities: [],
+  },
+  {
+    myValue: '广东',
+    myLabel: '广东',
+    cities: [
+      {
+        myValue: '深圳',
+        myLabel: '深圳',
+        cities: [],
+      },
+      {
+        myValue: '广州',
+        myLabel: '广州',
+        cities: [],
+        myDisabled: true,
+      },
+    ],
+  },
+];
+
+export const demoOptions3Props = {
+  value: 'myValue',
+  label: 'myLabel',
+  children: 'cities',
+  disabled: 'myDisabled',
+};

--- a/src/views/index/index.vue
+++ b/src/views/index/index.vue
@@ -8,6 +8,7 @@
     <router-link to="/divider">divider</router-link>
     <router-link to="/slider">slider</router-link>
     <router-link to="/switch">switch</router-link>
+    <router-link to="/cascader">cascader</router-link>
   </div>
 </template>
 <script>


### PR DESCRIPTION
提交cascader级联选择器组件。组件api参考elementUI设计，完成情况如下表：

elementUI参数 | 说明 | 类型 | 可选值 | 默认值 | pyUI实现
-- | -- | -- | -- | -- | --
options | 可选项数据源，键名可通过 props 属性配置 | array | — | — | 已实现
props | 配置选项，具体见下表 | object | — | — | 已实现
value | 选中项绑定值 | array | — | — | 已实现
separator | 选项分隔符 | string | — | 斜杠'/' | 已实现
popper-class | 自定义浮层类名 | string | — | — | 已实现(api接口改为 mune-class)
placeholder | 输入框占位文本 | string | — | 请选择 | 已实现
disabled | 是否禁用 | boolean | — | false | 已实现
clearable | 是否支持清空选项 | boolean | — | false | 已实现
expand-trigger | 次级菜单的展开方式 | string | click / hover | click | 已实现（api接口名改成 trigger-type）
show-all-levels | 输入框中是否显示选中值的完整路径 | boolean | — | true | 已实现
filterable | 是否可搜索选项 | boolean | — | — | 已实现
debounce | 搜索关键词输入的去抖延迟，毫秒 | number | — | 300 | 已实现
change-on-select | 是否允许选择任意一级的选项 | boolean | — | false | 已实现
size | 尺寸 | string | medium / small / mini | — | 已实现
before-filter | 筛选之前的钩子，参数为输入的值，若返回 false 或者返回 Promise 且被 reject，则停止筛选 | function(value) | — | — | 已实现

